### PR TITLE
Trim Actonic icon padding and update footer text

### DIFF
--- a/img/actonic.svg
+++ b/img/actonic.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 24.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 205 89" style="enable-background:new 0 0 205 89;" xml:space="preserve">
+         viewBox="0 0 73.8 89" style="enable-background:new 0 0 73.8 89;" xml:space="preserve">
 <style type="text/css">
         .st2{fill:#F7A600;}
 	.st3{fill:url(#SVGID_1_);}

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
         </a>
         <a href="https://actonic.de/en/" target="_blank" rel="noopener noreferrer">
           <img src="img/actonic.svg" alt="Actonic logo">
-          developed and supported in Actonic
+          Powered by Actonic
         </a>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Trim Actonic SVG's extra right-side space by reducing its viewbox width for balanced padding
- Replace "developed and supported in Actonic" with "Powered by Actonic" in footer link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5edb3a884832e81bc40cad19c1c18