### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
     :root{ --bg:#0B1021; --card:#121835; --ink:#E6E9F2; --muted:#A9B0C6; --accent:#4C9AFF; --danger:#FF5630; --chip:#1B2348; --radius:16px; --shadow:0 20px 40px rgba(0,0,0,.35);}  
     html,body{height:100%}
     body{margin:0;background:#0B1021;color:var(--ink);font-family:Inter,system-ui,Segoe UI,Roboto,Arial}
-    .wrap{max-width:1280px;margin:24px auto 64px;padding:0 20px}
+    .wrap{max-width:1280px;margin:clamp(16px,3vw,24px) auto clamp(40px,5vw,64px);padding:0 clamp(12px,2vw,20px)}
     header{display:flex;gap:16px;align-items:flex-start;justify-content:space-between;flex-wrap:wrap}
-    h1{margin:0 0 6px;font-size:28px;font-weight:700}
+    h1{margin:0 0 6px;font-size:clamp(24px,5vw,32px);font-weight:700}
     .sub{color:var(--muted);font-size:13px}
     .links{display:flex;gap:12px;align-items:center;font-size:13px}
     .links a{display:flex;align-items:center;gap:6px;color:var(--ink);text-decoration:none;white-space:nowrap}
@@ -27,30 +27,30 @@
     .file-input-display{cursor:pointer;padding:4px 8px;background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.2);border-radius:6px;color:var(--ink);font-size:11px;display:inline-block;min-width:150px}
     .btn{cursor:pointer;border:0;border-radius:10px;padding:8px 12px;font-weight:600;color:#0B1021;background:var(--accent)}
     .btn.ghost{background:transparent;color:var(--ink);border:1px solid rgba(255,255,255,.12)}
-    .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px}
+    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:16px;margin-top:16px}
     .card{padding:12px}
     .card h3{margin:4px 6px 10px;font-size:13px;font-weight:600;color:var(--muted);letter-spacing:.2px}
     .card h3.has-toolbar{display:flex;align-items:center}
     .card h3.has-toolbar .chart-toolbar{position:static;margin-left:auto}
-    .chart{height:520px;width:100%;display:flex;align-items:center;justify-content:center;position:relative}
+    .chart{height:clamp(280px,60vh,520px);width:100%;display:flex;align-items:center;justify-content:center;position:relative}
     .chart-toolbar{position:absolute;top:8px;right:8px;display:flex;gap:6px;z-index:10}
     .chart-toolbar .btn{padding:4px 6px;font-size:11px}
     .chart-toolbar .btn svg{width:16px;height:16px}
     .chart.flip{animation:flipY .6s}
     @keyframes flipY{0%{transform:rotateY(0)}50%{transform:rotateY(90deg)}100%{transform:rotateY(0)}}
-    .short{height:420px}
-    .tall{height:580px}
+    .short{height:clamp(220px,45vh,420px)}
+    .tall{height:clamp(320px,70vh,580px)}
     .chart .placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#8EA2E3;font-size:12px;letter-spacing:.2px}
     .status{font-size:12px;color:var(--muted);margin-top:6px;white-space:pre-line}
     input[type="range"]{accent-color:var(--accent)}
     input[type="file"]{color:var(--ink);font-size:12px}
     code.bad{color:var(--danger)}
-    .two-col{display:grid;grid-template-columns:1fr 1fr;gap:12px}
-    .mini-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+    .two-col{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px}
+    .mini-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}
     .mini{background:var(--card);border:1px solid rgba(255,255,255,.06);border-radius:12px;padding:10px}
     .help{display:inline-flex;align-items:center;justify-content:center;width:14px;height:14px;margin-left:4px;border-radius:50%;background:var(--muted);color:#0B1021;font-size:11px;font-weight:700;cursor:pointer}
     .tooltip{position:absolute;z-index:1000;max-width:220px;background:var(--card);color:var(--ink);border:1px solid rgba(255,255,255,.12);padding:6px 8px;font-size:11px;border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,.35);display:none;white-space:pre-wrap}
-    @media (max-width:980px){.grid{grid-template-columns:1fr}.chart{height:460px}.short{height:380px}.tall{height:520px}.two-col{grid-template-columns:1fr}}
+    @media (max-width:600px){.wrap{margin:16px auto 40px;padding:0 12px}header{flex-direction:column;align-items:flex-start}.links{flex-direction:column;align-items:flex-start;gap:8px}.controls{flex-direction:column;align-items:stretch}.controls button{width:100%}.chip{width:100%}}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- replace fixed grids with auto-fit layouts to adapt to any screen width
- scale headings and chart heights with CSS `clamp` for fluid resizing
- streamline small-screen media query to stack controls vertically

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a637a9f614832e99323bbfdebe68d5