### PR TITLE
Stack zero-result totals under popular keywords on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,11 +50,12 @@
     .mini{background:var(--card);border:1px solid rgba(255,255,255,.06);border-radius:12px;padding:10px}
     .help{display:inline-flex;align-items:center;justify-content:center;width:14px;height:14px;margin-left:4px;border-radius:50%;background:var(--muted);color:#0B1021;font-size:11px;font-weight:700;cursor:pointer}
     .tooltip{position:absolute;z-index:1000;max-width:220px;background:var(--card);color:var(--ink);border:1px solid rgba(255,255,255,.12);padding:6px 8px;font-size:11px;border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,.35);display:none;white-space:pre-wrap}
-    @media (max-width:980px){.grid{grid-template-columns:1fr}.chart{height:460px}.short{height:380px}.tall{height:520px}.two-col{grid-template-columns:1fr}}
+    @media (max-width:980px){.grid{grid-template-columns:1fr}.chart{height:460px}.short{height:380px}.tall{height:520px}.two-col{grid-template-columns:1fr}.mini-grid{grid-template-columns:1fr}}
     html.mobile .wrap{max-width:100%;margin:12px auto;padding:0 10px}
     html.mobile header{flex-direction:column;align-items:flex-start}
     html.mobile .controls{flex-direction:column;align-items:stretch}
     html.mobile .grid{grid-template-columns:1fr}
+    html.mobile .mini-grid{grid-template-columns:1fr}
     html.mobile .chart,html.mobile .short,html.mobile .tall{height:100vh}
     </style>
     <script>


### PR DESCRIPTION
## Summary
- Make bar race and zero-result totals charts stack vertically on mobile screens for easier viewing.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a644f43624832ebb1a869a5e8a05d0