### PR TITLE
Embed author profile card with contact links

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     .wrap{max-width:1280px;margin:24px auto 64px;padding:0 20px}
     .layout{position:relative}
     .main{}
-    .author-column{position:absolute;top:0;left:100%;width:260px;margin-left:40px}
+    .author-column{position:fixed;top:24px;right:0;width:260px}
     header{display:flex;gap:16px;align-items:flex-start;justify-content:space-between;flex-wrap:wrap}
     .author-card{background:var(--card);border:1px solid rgba(255,255,255,.08);border-radius:var(--radius);box-shadow:var(--shadow);padding:16px;font-size:13px;max-width:260px;text-align:left}
     .author-card img{width:96px;height:96px;border-radius:50%;object-fit:cover;display:block;margin:0 auto 12px}


### PR DESCRIPTION
## Summary
- embed author card with Rustem Shiriiazdanov's bio, photo and contact links in header
- remove modal overlay and local image asset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c80c0e4398832ea6f10c98210c11ec