### PR TITLE
Add toggle and margin for author information card

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,9 @@
     .wrap{max-width:1280px;margin:24px auto 64px;padding:0 20px}
     .layout{position:relative}
     .main{}
-    .author-column{position:fixed;top:24px;right:0;width:260px}
+    .author-column{position:fixed;top:24px;right:24px;width:260px;overflow:visible;transition:right .3s}
+    .author-column.collapsed{right:-236px}
+    .author-toggle{position:absolute;left:-24px;top:16px;width:24px;height:40px;display:flex;align-items:center;justify-content:center;background:var(--card);border:1px solid rgba(255,255,255,.08);border-right:0;border-radius:8px 0 0 8px;color:var(--ink);cursor:pointer;z-index:1}
     header{display:flex;gap:16px;align-items:flex-start;justify-content:space-between;flex-wrap:wrap}
     .author-card{background:var(--card);border:1px solid rgba(255,255,255,.08);border-radius:var(--radius);box-shadow:var(--shadow);padding:16px;font-size:13px;max-width:260px;text-align:left}
     .author-card img{width:96px;height:96px;border-radius:50%;object-fit:cover;display:block;margin:0 auto 12px}
@@ -243,6 +245,7 @@
         </section>
       </div>
       <aside class="author-column">
+        <button id="author-toggle" class="author-toggle" aria-label="Toggle author card">&lsaquo;</button>
         <div class="author-card">
           <img src="https://seibert.group/products/wp-content/uploads/elementor/thumbs/Rustem-Shiriiazdanov_rund_600px-r64m2m9otgwnhlnqpqjdt2ifqy9b0z5if53y46imiw.png" alt="Rustem Shiriiazdanov">
           <h2>Rustem Shiriiazdanov</h2>
@@ -342,6 +345,17 @@
           el.addEventListener('touchstart', show);
           el.addEventListener('touchend', hide);
         });
+      }
+
+      function initAuthorToggle(){
+        const column = document.querySelector('.author-column');
+        const btn = document.getElementById('author-toggle');
+        if(column && btn){
+          btn.addEventListener('click', ()=>{
+            column.classList.toggle('collapsed');
+            btn.innerHTML = column.classList.contains('collapsed') ? '&rsaquo;' : '&lsaquo;';
+          });
+        }
       }
 
     const state = {
@@ -1261,6 +1275,7 @@
       document.getElementById('zero-display').addEventListener('click', ()=>{ document.getElementById('file-zero').click(); });
 
       initHelp();
+      initAuthorToggle();
 
       // Try to autoload defaults on boot (works on GitHub Pages when files are in repo)
       autoLoadDefaults();


### PR DESCRIPTION
## Summary
- add left-edge toggle to collapse/expand author card
- offset author card from right side of viewport for breathing room

## Testing
- `npx --yes prettier --check index.html` *(fails: Code style issues found)*
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68c82392ac8c832eb54ecc93593da926