### PR TITLE
Add Raw Data Playground tab with Perspective widgets and visual linking

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
     .node-card{position:absolute;width:420px;min-width:320px;min-height:290px;border:1px solid rgba(255,255,255,.14);border-radius:12px;background:rgba(18,24,53,.9);box-shadow:var(--shadow);resize:both;overflow:hidden}
     .node-head{display:flex;align-items:center;justify-content:space-between;padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.1);cursor:grab}
     .node-meta{display:flex;gap:6px;align-items:center;font-size:12px;color:var(--muted)}
+    .node-state{font-size:11px;color:#8EA2E3}
     .node-body{height:calc(100% - 45px)}
     .node-body perspective-viewer{width:100%;height:100%}
     .node-fallback{height:100%;display:flex;align-items:center;justify-content:center;padding:12px;font-size:12px;color:var(--muted);text-align:center}
@@ -437,23 +438,32 @@
         })));
       }
 
-      function ensurePerspectiveStyles(){
-        if(state.playground.pspStylesLoaded) return;
+      async function ensurePerspectiveStyles(){
+        if(state.playground.pspStylesLoaded) return true;
+        if(state.playground.pspStylesPromise) return state.playground.pspStylesPromise;
         const cssUrls = [
           'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/variables.css',
           'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/icons.css',
           'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/pro.css',
           'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/themes.css'
         ];
-        for(const href of cssUrls){
-          if(document.querySelector(`link[data-psp-style="${href}"]`)) continue;
+        state.playground.pspStylesPromise = Promise.all(cssUrls.map((href)=> new Promise((resolve)=>{
+          const existing = document.querySelector(`link[data-psp-style="${href}"]`);
+          if(existing){
+            if(existing.dataset.pspLoaded === 'true') return resolve(true);
+            existing.addEventListener('load', ()=> resolve(true), { once:true });
+            existing.addEventListener('error', ()=> resolve(false), { once:true });
+            return;
+          }
           const link = document.createElement('link');
           link.rel = 'stylesheet';
           link.href = href;
           link.dataset.pspStyle = href;
+          link.addEventListener('load', ()=>{ link.dataset.pspLoaded = 'true'; resolve(true); }, { once:true });
+          link.addEventListener('error', ()=> resolve(false), { once:true });
           document.head.appendChild(link);
-        }
-        state.playground.pspStylesLoaded = true;
+        }))).then(()=>{ state.playground.pspStylesLoaded = true; return true; });
+        return state.playground.pspStylesPromise;
       }
 
       async function ensurePerspectiveLoaded(){
@@ -494,7 +504,7 @@
                 if(!window.perspective) window.perspective = state.playground.pspApi;
               }
             }
-            ensurePerspectiveStyles();
+            await ensurePerspectiveStyles();
             state.playground.pspReady = !!((state.playground.pspApi || window.perspective) && customElements.get('perspective-viewer'));
             return state.playground.pspReady;
           }catch(e){
@@ -552,7 +562,7 @@
         el.style.left = `${node.x}px`;
         el.style.top = `${node.y}px`;
         el.dataset.nodeId = String(id);
-        el.innerHTML = `<div class="node-head"><div class="node-meta">Widget #${id}</div><button class="btn ghost" data-node-link="${id}" style="padding:4px 8px">Select</button></div><div class="node-body"><div class="node-fallback">Loading widget…</div></div>`;
+        el.innerHTML = `<div class="node-head"><div class="node-meta">Widget #${id} <span class="node-state">Loading…</span></div><button class="btn ghost" data-node-link="${id}" style="padding:4px 8px">Select</button></div><div class="node-body"><div class="node-fallback">Loading widget…</div></div>`;
         canvas.appendChild(el);
 
         const head = el.querySelector('.node-head');
@@ -595,13 +605,20 @@
           }
         });
         const body = el.querySelector('.node-body');
+        const nodeState = el.querySelector('.node-state');
         const ok = await ensurePerspectiveLoaded();
         if(ok){
           try{
+            const rows = getCombinedRows();
+            if(!rows.length){
+              body.innerHTML = `<div class="node-fallback">No data yet. Upload Popular/Zero files or click <b>Load demo</b>, then add a widget again.</div>`;
+              if(nodeState) nodeState.textContent = 'No data';
+              setStatus(`Widget #${id}: no data`);
+              return;
+            }
             body.innerHTML = '<perspective-viewer></perspective-viewer>';
             const viewer = body.querySelector('perspective-viewer');
             viewer.setAttribute('settings', '');
-            const rows = getCombinedRows();
             const perspectiveApi = state.playground.pspApi || window.perspective;
             const payload = rows.length ? rows : [{id:1, source:'empty', month:'-', keyword:'-', value:0}];
             let table;
@@ -623,15 +640,18 @@
               const ro = new ResizeObserver(()=> viewer.resize?.());
               ro.observe(el);
             }
+            if(nodeState) nodeState.textContent = `Rows: ${rows.length}`;
             setStatus(`Widget #${id} ready`);
           }catch(e){
             console.error('Perspective widget init failed', e);
             body.innerHTML = `<div class="node-fallback">Perspective failed to initialize in this browser session. You can still drag and link nodes, and retry by creating a new widget.</div>`;
+            if(nodeState) nodeState.textContent = 'Error';
             setStatus(`Widget #${id}: fallback mode`);
           }
         }else{
           const details = state.playground.lastError ? `<br><br><code>${state.playground.lastError}</code>` : '';
           body.innerHTML = `<div class="node-fallback">Perspective modules failed to load in this browser session.${details}</div>`;
+          if(nodeState) nodeState.textContent = 'Error';
           setStatus(`Widget #${id}: fallback mode`);
         }
         renderLinks();
@@ -669,7 +689,7 @@
         heatTimeStartIdx: 0, heatTimeEndIdx: 0, heatTimeRangeInitialized: false, trailsLegendPage: 0, trailsLegendCols: 3, trailsLegendRows: 2, trailsLegendTotalPages: 1,
         // default data autoload flags
         manualSource: false, manualZero: false, defaultsTried: false,
-        playground: { nextId: 1, linkMode: false, selectedParentId: null, nodes: [], links: [], pspReady: false, pspLoadingPromise: null, pspApi: null, pspStylesLoaded: false, lastError: '' }
+        playground: { nextId: 1, linkMode: false, selectedParentId: null, nodes: [], links: [], pspReady: false, pspLoadingPromise: null, pspApi: null, pspStylesLoaded: false, pspStylesPromise: null, lastError: '' }
       };
 
       const ICON_DOWNLOAD = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>`;

--- a/index.html
+++ b/index.html
@@ -441,10 +441,10 @@
         if(state.playground.pspReady) return true;
         if(state.playground.pspLoadingPromise) return state.playground.pspLoadingPromise;
         const bundles = [
-          ['https://cdn.jsdelivr.net/npm/@finos/perspective/dist/esm/perspective.js', 'https://unpkg.com/@finos/perspective/dist/esm/perspective.js'],
-          ['https://cdn.jsdelivr.net/npm/@finos/perspective-viewer/dist/esm/perspective-viewer.js', 'https://unpkg.com/@finos/perspective-viewer/dist/esm/perspective-viewer.js'],
-          ['https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid/dist/esm/perspective-viewer-datagrid.js', 'https://unpkg.com/@finos/perspective-viewer-datagrid/dist/esm/perspective-viewer-datagrid.js'],
-          ['https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc/dist/esm/perspective-viewer-d3fc.js', 'https://unpkg.com/@finos/perspective-viewer-d3fc/dist/esm/perspective-viewer-d3fc.js']
+          ['https://esm.sh/@finos/perspective@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective/dist/esm/perspective.js'],
+          ['https://esm.sh/@finos/perspective-viewer@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer/dist/esm/perspective-viewer.js'],
+          ['https://esm.sh/@finos/perspective-viewer-datagrid@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid/dist/esm/perspective-viewer-datagrid.js'],
+          ['https://esm.sh/@finos/perspective-viewer-d3fc@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc/dist/esm/perspective-viewer-d3fc.js']
         ];
         state.playground.pspLoadingPromise = (async ()=>{
           try{
@@ -455,7 +455,7 @@
                   const mod = await import(url);
                   return mod;
                 }catch(e){
-                  console.warn('Perspective module failed', url);
+                  console.warn('Perspective module failed', url, e?.message || e);
                 }
               }
               return null;

--- a/index.html
+++ b/index.html
@@ -439,54 +439,45 @@
 
       async function ensurePerspectiveLoaded(){
         if(state.playground.pspReady) return true;
+        if(state.playground.pspLoadingPromise) return state.playground.pspLoadingPromise;
         const bundles = [
-          [
-            'https://cdn.jsdelivr.net/npm/@finos/perspective/dist/cdn/perspective.js',
-            'https://unpkg.com/@finos/perspective/dist/cdn/perspective.js'
-          ],
-          [
-            'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer/dist/cdn/perspective-viewer.js',
-            'https://unpkg.com/@finos/perspective-viewer/dist/cdn/perspective-viewer.js'
-          ],
-          [
-            'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid/dist/cdn/perspective-viewer-datagrid.js',
-            'https://unpkg.com/@finos/perspective-viewer-datagrid/dist/cdn/perspective-viewer-datagrid.js'
-          ],
-          [
-            'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc/dist/cdn/perspective-viewer-d3fc.js',
-            'https://unpkg.com/@finos/perspective-viewer-d3fc/dist/cdn/perspective-viewer-d3fc.js'
-          ]
+          ['https://cdn.jsdelivr.net/npm/@finos/perspective/dist/esm/perspective.js', 'https://unpkg.com/@finos/perspective/dist/esm/perspective.js'],
+          ['https://cdn.jsdelivr.net/npm/@finos/perspective-viewer/dist/esm/perspective-viewer.js', 'https://unpkg.com/@finos/perspective-viewer/dist/esm/perspective-viewer.js'],
+          ['https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid/dist/esm/perspective-viewer-datagrid.js', 'https://unpkg.com/@finos/perspective-viewer-datagrid/dist/esm/perspective-viewer-datagrid.js'],
+          ['https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc/dist/esm/perspective-viewer-d3fc.js', 'https://unpkg.com/@finos/perspective-viewer-d3fc/dist/esm/perspective-viewer-d3fc.js']
         ];
-        try{
-          const loadAny = async (urls)=>{
-            for(const url of urls){
-              try{
-                // eslint-disable-next-line no-await-in-loop
-                await new Promise((resolve, reject)=>{
-                  const s = document.createElement('script');
-                  s.src = url;
-                  s.onload = resolve;
-                  s.onerror = reject;
-                  document.head.appendChild(s);
-                });
-                return true;
-              }catch(e){
-                console.warn('Perspective script failed', url);
+        state.playground.pspLoadingPromise = (async ()=>{
+          try{
+            const loadModuleAny = async (urls)=>{
+              for(const url of urls){
+                try{
+                  // eslint-disable-next-line no-await-in-loop
+                  const mod = await import(url);
+                  return mod;
+                }catch(e){
+                  console.warn('Perspective module failed', url);
+                }
+              }
+              return null;
+            };
+            for(let idx=0; idx<bundles.length; idx++){
+              // eslint-disable-next-line no-await-in-loop
+              const mod = await loadModuleAny(bundles[idx]);
+              if(!mod) throw new Error('Unable to load one of Perspective bundles');
+              if(idx === 0){
+                state.playground.pspApi = mod.default || mod;
+                if(!window.perspective) window.perspective = state.playground.pspApi;
               }
             }
+            state.playground.pspReady = !!((state.playground.pspApi || window.perspective) && customElements.get('perspective-viewer'));
+            return state.playground.pspReady;
+          }catch(e){
+            console.error('Perspective load failed', e);
+            state.playground.pspLoadingPromise = null;
             return false;
-          };
-          for(const urlGroup of bundles){
-            // eslint-disable-next-line no-await-in-loop
-            const loaded = await loadAny(urlGroup);
-            if(!loaded) throw new Error('Unable to load one of Perspective bundles');
           }
-          state.playground.pspReady = !!(window.perspective && customElements.get('perspective-viewer'));
-          return state.playground.pspReady;
-        }catch(e){
-          console.error('Perspective load failed', e);
-          return false;
-        }
+        })();
+        return state.playground.pspLoadingPromise;
       }
 
       function updateMappingsLabel(){
@@ -583,7 +574,8 @@
             body.innerHTML = '<perspective-viewer></perspective-viewer>';
             const viewer = body.querySelector('perspective-viewer');
             const rows = getCombinedRows();
-            const table = await window.perspective.worker().table(rows.length ? rows : [{id:1, source:'empty', month:'-', keyword:'-', value:0}]);
+            const perspectiveApi = state.playground.pspApi || window.perspective;
+            const table = await perspectiveApi.worker().table(rows.length ? rows : [{id:1, source:'empty', month:'-', keyword:'-', value:0}]);
             await viewer.load(table);
             await viewer.restore({settings:true, plugin:'Datagrid'});
             setStatus(`Widget #${id} ready`);
@@ -631,7 +623,7 @@
         heatTimeStartIdx: 0, heatTimeEndIdx: 0, heatTimeRangeInitialized: false, trailsLegendPage: 0, trailsLegendCols: 3, trailsLegendRows: 2, trailsLegendTotalPages: 1,
         // default data autoload flags
         manualSource: false, manualZero: false, defaultsTried: false,
-        playground: { nextId: 1, linkMode: false, selectedParentId: null, nodes: [], links: [], pspReady: false }
+        playground: { nextId: 1, linkMode: false, selectedParentId: null, nodes: [], links: [], pspReady: false, pspLoadingPromise: null, pspApi: null }
       };
 
       const ICON_DOWNLOAD = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>`;

--- a/index.html
+++ b/index.html
@@ -40,10 +40,10 @@
     .playground-toolbar .chip{padding:6px 10px}
     .canvas-wrap{position:relative;overflow:auto;height:72vh;border:1px solid rgba(255,255,255,.12);border-radius:12px;background:#0a0f24}
     .canvas-inner{position:relative;width:3600px;height:2200px;background-image:radial-gradient(rgba(255,255,255,.14) 1px, transparent 0);background-size:26px 26px}
-    .node-card{position:absolute;width:420px;min-height:290px;border:1px solid rgba(255,255,255,.14);border-radius:12px;background:rgba(18,24,53,.9);box-shadow:var(--shadow)}
+    .node-card{position:absolute;width:420px;min-width:320px;min-height:290px;border:1px solid rgba(255,255,255,.14);border-radius:12px;background:rgba(18,24,53,.9);box-shadow:var(--shadow);resize:both;overflow:hidden}
     .node-head{display:flex;align-items:center;justify-content:space-between;padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.1);cursor:grab}
     .node-meta{display:flex;gap:6px;align-items:center;font-size:12px;color:var(--muted)}
-    .node-body{height:240px}
+    .node-body{height:calc(100% - 45px)}
     .node-body perspective-viewer{width:100%;height:100%}
     .node-fallback{height:100%;display:flex;align-items:center;justify-content:center;padding:12px;font-size:12px;color:var(--muted);text-align:center}
     .link-layer{position:absolute;inset:0;pointer-events:none}
@@ -443,7 +443,8 @@
         const bundles = [
           { required: true, urls: ['https://unpkg.com/@finos/perspective?module', 'https://esm.sh/@finos/perspective@latest?bundle'] },
           { required: true, urls: ['https://unpkg.com/@finos/perspective-viewer?module', 'https://esm.sh/@finos/perspective-viewer@latest?bundle'] },
-          { required: true, urls: ['https://unpkg.com/@finos/perspective-viewer-datagrid?module', 'https://esm.sh/@finos/perspective-viewer-datagrid@latest?bundle'] }
+          { required: true, urls: ['https://unpkg.com/@finos/perspective-viewer-datagrid?module', 'https://esm.sh/@finos/perspective-viewer-datagrid@latest?bundle'] },
+          { required: false, urls: ['https://unpkg.com/@finos/perspective-viewer-d3fc?module', 'https://esm.sh/@finos/perspective-viewer-d3fc@latest?bundle'] }
         ];
         state.playground.lastError = '';
         state.playground.pspLoadingPromise = (async ()=>{
@@ -464,7 +465,11 @@
             for(let idx=0; idx<bundles.length; idx++){
               // eslint-disable-next-line no-await-in-loop
               const mod = await loadModuleAny(bundles[idx].urls);
-              if(!mod) throw new Error('Unable to load one of Perspective required bundles');
+              if(!mod){
+                if(bundles[idx].required) throw new Error('Unable to load one of Perspective required bundles');
+                console.warn('Optional Perspective plugin failed to load');
+                continue;
+              }
               if(idx === 0){
                 state.playground.pspApi = mod.default || mod;
                 if(!window.perspective) window.perspective = state.playground.pspApi;
@@ -575,6 +580,7 @@
           try{
             body.innerHTML = '<perspective-viewer></perspective-viewer>';
             const viewer = body.querySelector('perspective-viewer');
+            viewer.setAttribute('settings', '');
             const rows = getCombinedRows();
             const perspectiveApi = state.playground.pspApi || window.perspective;
             const payload = rows.length ? rows : [{id:1, source:'empty', month:'-', keyword:'-', value:0}];
@@ -593,6 +599,10 @@
             }
             await viewer.load(table);
             await viewer.restore({settings:true, plugin:'Datagrid'});
+            if(window.ResizeObserver){
+              const ro = new ResizeObserver(()=> viewer.resize?.());
+              ro.observe(el);
+            }
             setStatus(`Widget #${id} ready`);
           }catch(e){
             console.error('Perspective widget init failed', e);

--- a/index.html
+++ b/index.html
@@ -437,6 +437,25 @@
         })));
       }
 
+      function ensurePerspectiveStyles(){
+        if(state.playground.pspStylesLoaded) return;
+        const cssUrls = [
+          'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/variables.css',
+          'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/icons.css',
+          'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/pro.css',
+          'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/themes.css'
+        ];
+        for(const href of cssUrls){
+          if(document.querySelector(`link[data-psp-style="${href}"]`)) continue;
+          const link = document.createElement('link');
+          link.rel = 'stylesheet';
+          link.href = href;
+          link.dataset.pspStyle = href;
+          document.head.appendChild(link);
+        }
+        state.playground.pspStylesLoaded = true;
+      }
+
       async function ensurePerspectiveLoaded(){
         if(state.playground.pspReady) return true;
         if(state.playground.pspLoadingPromise) return state.playground.pspLoadingPromise;
@@ -475,6 +494,7 @@
                 if(!window.perspective) window.perspective = state.playground.pspApi;
               }
             }
+            ensurePerspectiveStyles();
             state.playground.pspReady = !!((state.playground.pspApi || window.perspective) && customElements.get('perspective-viewer'));
             return state.playground.pspReady;
           }catch(e){
@@ -598,7 +618,7 @@
               throw new Error('Perspective API did not expose a usable table() constructor');
             }
             await viewer.load(table);
-            await viewer.restore({settings:true, plugin:'Datagrid'});
+            await viewer.restore({settings:true, plugin:'Datagrid', theme:'Pro Light'});
             if(window.ResizeObserver){
               const ro = new ResizeObserver(()=> viewer.resize?.());
               ro.observe(el);
@@ -649,7 +669,7 @@
         heatTimeStartIdx: 0, heatTimeEndIdx: 0, heatTimeRangeInitialized: false, trailsLegendPage: 0, trailsLegendCols: 3, trailsLegendRows: 2, trailsLegendTotalPages: 1,
         // default data autoload flags
         manualSource: false, manualZero: false, defaultsTried: false,
-        playground: { nextId: 1, linkMode: false, selectedParentId: null, nodes: [], links: [], pspReady: false, pspLoadingPromise: null, pspApi: null, lastError: '' }
+        playground: { nextId: 1, linkMode: false, selectedParentId: null, nodes: [], links: [], pspReady: false, pspLoadingPromise: null, pspApi: null, pspStylesLoaded: false, lastError: '' }
       };
 
       const ICON_DOWNLOAD = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>`;

--- a/index.html
+++ b/index.html
@@ -441,10 +441,10 @@
         if(state.playground.pspReady) return true;
         if(state.playground.pspLoadingPromise) return state.playground.pspLoadingPromise;
         const bundles = [
-          ['https://esm.sh/@finos/perspective@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective/dist/esm/perspective.js'],
-          ['https://esm.sh/@finos/perspective-viewer@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer/dist/esm/perspective-viewer.js'],
-          ['https://esm.sh/@finos/perspective-viewer-datagrid@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid/dist/esm/perspective-viewer-datagrid.js'],
-          ['https://esm.sh/@finos/perspective-viewer-d3fc@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc/dist/esm/perspective-viewer-d3fc.js']
+          { required: true, urls: ['https://esm.sh/@finos/perspective@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective/dist/esm/perspective.js'] },
+          { required: true, urls: ['https://esm.sh/@finos/perspective-viewer@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer/dist/esm/perspective-viewer.js'] },
+          { required: true, urls: ['https://esm.sh/@finos/perspective-viewer-datagrid@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid/dist/esm/perspective-viewer-datagrid.js'] },
+          { required: false, urls: ['https://esm.sh/@finos/perspective-viewer-d3fc@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc/dist/esm/perspective-viewer-d3fc.js'] }
         ];
         state.playground.pspLoadingPromise = (async ()=>{
           try{
@@ -462,8 +462,12 @@
             };
             for(let idx=0; idx<bundles.length; idx++){
               // eslint-disable-next-line no-await-in-loop
-              const mod = await loadModuleAny(bundles[idx]);
-              if(!mod) throw new Error('Unable to load one of Perspective bundles');
+              const mod = await loadModuleAny(bundles[idx].urls);
+              if(!mod){
+                if(bundles[idx].required) throw new Error('Unable to load one of Perspective required bundles');
+                console.warn('Optional Perspective plugin unavailable; continuing without it');
+                continue;
+              }
               if(idx === 0){
                 state.playground.pspApi = mod.default || mod;
                 if(!window.perspective) window.perspective = state.playground.pspApi;

--- a/index.html
+++ b/index.html
@@ -45,7 +45,6 @@
     .node-meta{display:flex;gap:6px;align-items:center;font-size:12px;color:var(--muted)}
     .node-body{height:240px}
     .node-body perspective-viewer{width:100%;height:100%}
-    .node-body iframe{width:100%;height:100%;border:0}
     .node-fallback{height:100%;display:flex;align-items:center;justify-content:center;padding:12px;font-size:12px;color:var(--muted);text-align:center}
     .link-layer{position:absolute;inset:0;pointer-events:none}
     .mapping-list{font-size:12px;color:var(--muted);max-height:120px;overflow:auto}
@@ -440,22 +439,47 @@
 
       async function ensurePerspectiveLoaded(){
         if(state.playground.pspReady) return true;
-        const urls = [
-          'https://cdn.jsdelivr.net/npm/@finos/perspective@2.11.0/dist/cdn/perspective.js',
-          'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer@2.11.0/dist/cdn/perspective-viewer.js',
-          'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid@2.11.0/dist/cdn/perspective-viewer-datagrid.js',
-          'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc@2.11.0/dist/cdn/perspective-viewer-d3fc.js'
+        const bundles = [
+          [
+            'https://cdn.jsdelivr.net/npm/@finos/perspective/dist/cdn/perspective.js',
+            'https://unpkg.com/@finos/perspective/dist/cdn/perspective.js'
+          ],
+          [
+            'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer/dist/cdn/perspective-viewer.js',
+            'https://unpkg.com/@finos/perspective-viewer/dist/cdn/perspective-viewer.js'
+          ],
+          [
+            'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid/dist/cdn/perspective-viewer-datagrid.js',
+            'https://unpkg.com/@finos/perspective-viewer-datagrid/dist/cdn/perspective-viewer-datagrid.js'
+          ],
+          [
+            'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc/dist/cdn/perspective-viewer-d3fc.js',
+            'https://unpkg.com/@finos/perspective-viewer-d3fc/dist/cdn/perspective-viewer-d3fc.js'
+          ]
         ];
         try{
-          for(const url of urls){
+          const loadAny = async (urls)=>{
+            for(const url of urls){
+              try{
+                // eslint-disable-next-line no-await-in-loop
+                await new Promise((resolve, reject)=>{
+                  const s = document.createElement('script');
+                  s.src = url;
+                  s.onload = resolve;
+                  s.onerror = reject;
+                  document.head.appendChild(s);
+                });
+                return true;
+              }catch(e){
+                console.warn('Perspective script failed', url);
+              }
+            }
+            return false;
+          };
+          for(const urlGroup of bundles){
             // eslint-disable-next-line no-await-in-loop
-            await new Promise((resolve, reject)=>{
-              const s = document.createElement('script');
-              s.src = url;
-              s.onload = resolve;
-              s.onerror = reject;
-              document.head.appendChild(s);
-            });
+            const loaded = await loadAny(urlGroup);
+            if(!loaded) throw new Error('Unable to load one of Perspective bundles');
           }
           state.playground.pspReady = !!(window.perspective && customElements.get('perspective-viewer'));
           return state.playground.pspReady;
@@ -565,11 +589,11 @@
             setStatus(`Widget #${id} ready`);
           }catch(e){
             console.error('Perspective widget init failed', e);
-            body.innerHTML = `<div class="node-fallback">Perspective failed to initialize. Opening editable demo fallback below.</div><iframe title="Perspective editable demo" src="https://perspective-dev.github.io/block/?example=editable"></iframe>`;
+            body.innerHTML = `<div class="node-fallback">Perspective failed to initialize in this browser session. You can still drag and link nodes, and retry by creating a new widget.</div>`;
             setStatus(`Widget #${id}: fallback mode`);
           }
         }else{
-          body.innerHTML = `<div class="node-fallback">Perspective CDN not reachable in this environment. Showing editable fallback demo.</div><iframe title="Perspective editable demo" src="https://perspective-dev.github.io/block/?example=editable"></iframe>`;
+          body.innerHTML = `<div class="node-fallback">Perspective CDN is not available right now. Please check your network/CDN access and try again.</div>`;
           setStatus(`Widget #${id}: fallback mode`);
         }
         renderLinks();

--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
     .node-meta{display:flex;gap:6px;align-items:center;font-size:12px;color:var(--muted)}
     .node-body{height:240px}
     .node-body perspective-viewer{width:100%;height:100%}
+    .node-body iframe{width:100%;height:100%;border:0}
+    .node-fallback{height:100%;display:flex;align-items:center;justify-content:center;padding:12px;font-size:12px;color:var(--muted);text-align:center}
     .link-layer{position:absolute;inset:0;pointer-events:none}
     .mapping-list{font-size:12px;color:var(--muted);max-height:120px;overflow:auto}
     .panel{background:linear-gradient(180deg,rgba(255,255,255,.02),rgba(255,255,255,.00));border:1px solid rgba(255,255,255,.08);border-radius:var(--radius);box-shadow:var(--shadow)}
@@ -455,10 +457,10 @@
               document.head.appendChild(s);
             });
           }
-          state.playground.pspReady = true;
-          return true;
+          state.playground.pspReady = !!(window.perspective && customElements.get('perspective-viewer'));
+          return state.playground.pspReady;
         }catch(e){
-          setStatus('Perspective.js failed to load for raw playground');
+          console.error('Perspective load failed', e);
           return false;
         }
       }
@@ -497,10 +499,9 @@
       }
 
       async function createPlaygroundNode(){
-        const ok = await ensurePerspectiveLoaded();
-        if(!ok) return;
         const canvas = document.getElementById('canvas-inner');
         if(!canvas) return;
+        setStatus('Creating Perspective widget…');
         const id = state.playground.nextId++;
         const node = { id, x: 120 + (id-1) * 40, y: 120 + (id-1) * 30 };
         state.playground.nodes.push(node);
@@ -509,13 +510,8 @@
         el.style.left = `${node.x}px`;
         el.style.top = `${node.y}px`;
         el.dataset.nodeId = String(id);
-        el.innerHTML = `<div class="node-head"><div class="node-meta">Widget #${id}</div><button class="btn ghost" data-node-link="${id}" style="padding:4px 8px">Select</button></div><div class="node-body"><perspective-viewer></perspective-viewer></div>`;
+        el.innerHTML = `<div class="node-head"><div class="node-meta">Widget #${id}</div><button class="btn ghost" data-node-link="${id}" style="padding:4px 8px">Select</button></div><div class="node-body"><div class="node-fallback">Loading widget…</div></div>`;
         canvas.appendChild(el);
-        const viewer = el.querySelector('perspective-viewer');
-        const rows = getCombinedRows();
-        const table = await window.perspective.worker().table(rows.length ? rows : [{id:1, source:'empty', month:'-', keyword:'-', value:0}]);
-        await viewer.load(table);
-        await viewer.restore({settings:true, plugin:'Datagrid'});
 
         const head = el.querySelector('.node-head');
         head.addEventListener('mousedown', (evt)=>{
@@ -556,6 +552,26 @@
             renderLinks();
           }
         });
+        const body = el.querySelector('.node-body');
+        const ok = await ensurePerspectiveLoaded();
+        if(ok){
+          try{
+            body.innerHTML = '<perspective-viewer></perspective-viewer>';
+            const viewer = body.querySelector('perspective-viewer');
+            const rows = getCombinedRows();
+            const table = await window.perspective.worker().table(rows.length ? rows : [{id:1, source:'empty', month:'-', keyword:'-', value:0}]);
+            await viewer.load(table);
+            await viewer.restore({settings:true, plugin:'Datagrid'});
+            setStatus(`Widget #${id} ready`);
+          }catch(e){
+            console.error('Perspective widget init failed', e);
+            body.innerHTML = `<div class="node-fallback">Perspective failed to initialize. Opening editable demo fallback below.</div><iframe title="Perspective editable demo" src="https://perspective-dev.github.io/block/?example=editable"></iframe>`;
+            setStatus(`Widget #${id}: fallback mode`);
+          }
+        }else{
+          body.innerHTML = `<div class="node-fallback">Perspective CDN not reachable in this environment. Showing editable fallback demo.</div><iframe title="Perspective editable demo" src="https://perspective-dev.github.io/block/?example=editable"></iframe>`;
+          setStatus(`Widget #${id}: fallback mode`);
+        }
         renderLinks();
       }
 

--- a/index.html
+++ b/index.html
@@ -441,10 +441,11 @@
         if(state.playground.pspReady) return true;
         if(state.playground.pspLoadingPromise) return state.playground.pspLoadingPromise;
         const bundles = [
-          { required: true, urls: ['https://esm.sh/@finos/perspective@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective/dist/esm/perspective.js'] },
-          { required: true, urls: ['https://esm.sh/@finos/perspective-viewer@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer/dist/esm/perspective-viewer.js'] },
-          { required: true, urls: ['https://esm.sh/@finos/perspective-viewer-datagrid@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid/dist/esm/perspective-viewer-datagrid.js'] }
+          { required: true, urls: ['https://unpkg.com/@finos/perspective?module', 'https://esm.sh/@finos/perspective@latest?bundle'] },
+          { required: true, urls: ['https://unpkg.com/@finos/perspective-viewer?module', 'https://esm.sh/@finos/perspective-viewer@latest?bundle'] },
+          { required: true, urls: ['https://unpkg.com/@finos/perspective-viewer-datagrid?module', 'https://esm.sh/@finos/perspective-viewer-datagrid@latest?bundle'] }
         ];
+        state.playground.lastError = '';
         state.playground.pspLoadingPromise = (async ()=>{
           try{
             const loadModuleAny = async (urls)=>{
@@ -454,6 +455,7 @@
                   const mod = await import(url);
                   return mod;
                 }catch(e){
+                  state.playground.lastError = `${url}: ${e?.message || e}`;
                   console.warn('Perspective module failed', url, e?.message || e);
                 }
               }
@@ -472,6 +474,7 @@
             return state.playground.pspReady;
           }catch(e){
             console.error('Perspective load failed', e);
+            state.playground.lastError = e?.message || String(e);
             state.playground.pspLoadingPromise = null;
             return false;
           }
@@ -584,7 +587,8 @@
             setStatus(`Widget #${id}: fallback mode`);
           }
         }else{
-          body.innerHTML = `<div class="node-fallback">Perspective CDN is not available right now. Please check your network/CDN access and try again.</div>`;
+          const details = state.playground.lastError ? `<br><br><code>${state.playground.lastError}</code>` : '';
+          body.innerHTML = `<div class="node-fallback">Perspective modules failed to load in this browser session.${details}</div>`;
           setStatus(`Widget #${id}: fallback mode`);
         }
         renderLinks();
@@ -622,7 +626,7 @@
         heatTimeStartIdx: 0, heatTimeEndIdx: 0, heatTimeRangeInitialized: false, trailsLegendPage: 0, trailsLegendCols: 3, trailsLegendRows: 2, trailsLegendTotalPages: 1,
         // default data autoload flags
         manualSource: false, manualZero: false, defaultsTried: false,
-        playground: { nextId: 1, linkMode: false, selectedParentId: null, nodes: [], links: [], pspReady: false, pspLoadingPromise: null, pspApi: null }
+        playground: { nextId: 1, linkMode: false, selectedParentId: null, nodes: [], links: [], pspReady: false, pspLoadingPromise: null, pspApi: null, lastError: '' }
       };
 
       const ICON_DOWNLOAD = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>`;

--- a/index.html
+++ b/index.html
@@ -443,8 +443,7 @@
         const bundles = [
           { required: true, urls: ['https://esm.sh/@finos/perspective@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective/dist/esm/perspective.js'] },
           { required: true, urls: ['https://esm.sh/@finos/perspective-viewer@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer/dist/esm/perspective-viewer.js'] },
-          { required: true, urls: ['https://esm.sh/@finos/perspective-viewer-datagrid@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid/dist/esm/perspective-viewer-datagrid.js'] },
-          { required: false, urls: ['https://esm.sh/@finos/perspective-viewer-d3fc@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc/dist/esm/perspective-viewer-d3fc.js'] }
+          { required: true, urls: ['https://esm.sh/@finos/perspective-viewer-datagrid@latest?bundle', 'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid/dist/esm/perspective-viewer-datagrid.js'] }
         ];
         state.playground.pspLoadingPromise = (async ()=>{
           try{
@@ -463,11 +462,7 @@
             for(let idx=0; idx<bundles.length; idx++){
               // eslint-disable-next-line no-await-in-loop
               const mod = await loadModuleAny(bundles[idx].urls);
-              if(!mod){
-                if(bundles[idx].required) throw new Error('Unable to load one of Perspective required bundles');
-                console.warn('Optional Perspective plugin unavailable; continuing without it');
-                continue;
-              }
+              if(!mod) throw new Error('Unable to load one of Perspective required bundles');
               if(idx === 0){
                 state.playground.pspApi = mod.default || mod;
                 if(!window.perspective) window.perspective = state.playground.pspApi;

--- a/index.html
+++ b/index.html
@@ -577,7 +577,20 @@
             const viewer = body.querySelector('perspective-viewer');
             const rows = getCombinedRows();
             const perspectiveApi = state.playground.pspApi || window.perspective;
-            const table = await perspectiveApi.worker().table(rows.length ? rows : [{id:1, source:'empty', month:'-', keyword:'-', value:0}]);
+            const payload = rows.length ? rows : [{id:1, source:'empty', month:'-', keyword:'-', value:0}];
+            let table;
+            if(typeof perspectiveApi.worker === 'function'){
+              const workerClient = await perspectiveApi.worker();
+              if(workerClient && typeof workerClient.table === 'function'){
+                table = await workerClient.table(payload);
+              }
+            }
+            if(!table && typeof perspectiveApi.table === 'function'){
+              table = await perspectiveApi.table(payload);
+            }
+            if(!table){
+              throw new Error('Perspective API did not expose a usable table() constructor');
+            }
             await viewer.load(table);
             await viewer.restore({settings:true, plugin:'Datagrid'});
             setStatus(`Widget #${id} ready`);

--- a/index.html
+++ b/index.html
@@ -30,6 +30,23 @@
     .links a:hover{color:var(--accent)}
     .links img,.links svg{height:16px;width:16px}
     .links button{font-size:13px;white-space:nowrap}
+    .tabs{display:flex;gap:8px;margin-top:16px}
+    .tab-btn{cursor:pointer;border:1px solid rgba(255,255,255,.14);background:var(--chip);color:var(--ink);border-radius:10px;padding:8px 12px;font-weight:600}
+    .tab-btn.active{background:var(--accent);color:#0B1021;border-color:transparent}
+    .tab-panel{display:none;margin-top:12px}
+    .tab-panel.active{display:block}
+    .playground-shell{display:flex;flex-direction:column;gap:12px}
+    .playground-toolbar{display:flex;gap:10px;align-items:center;flex-wrap:wrap;padding:12px;background:var(--card);border-radius:12px}
+    .playground-toolbar .chip{padding:6px 10px}
+    .canvas-wrap{position:relative;overflow:auto;height:72vh;border:1px solid rgba(255,255,255,.12);border-radius:12px;background:#0a0f24}
+    .canvas-inner{position:relative;width:3600px;height:2200px;background-image:radial-gradient(rgba(255,255,255,.14) 1px, transparent 0);background-size:26px 26px}
+    .node-card{position:absolute;width:420px;min-height:290px;border:1px solid rgba(255,255,255,.14);border-radius:12px;background:rgba(18,24,53,.9);box-shadow:var(--shadow)}
+    .node-head{display:flex;align-items:center;justify-content:space-between;padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.1);cursor:grab}
+    .node-meta{display:flex;gap:6px;align-items:center;font-size:12px;color:var(--muted)}
+    .node-body{height:240px}
+    .node-body perspective-viewer{width:100%;height:100%}
+    .link-layer{position:absolute;inset:0;pointer-events:none}
+    .mapping-list{font-size:12px;color:var(--muted);max-height:120px;overflow:auto}
     .panel{background:linear-gradient(180deg,rgba(255,255,255,.02),rgba(255,255,255,.00));border:1px solid rgba(255,255,255,.08);border-radius:var(--radius);box-shadow:var(--shadow)}
     .controls{display:flex;gap:12px;align-items:center;flex-wrap:wrap;padding:14px;background:var(--card);border-radius:var(--radius)}
     .controls.soft{padding:10px;margin-top:8px}
@@ -135,8 +152,13 @@
             <button id="btn-share-page" class="btn ghost" aria-label="Share page"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg></button>
           </div>
         </header>
+        <div class="tabs">
+          <button class="tab-btn active" data-tab="dashboard">Dashboard</button>
+          <button class="tab-btn" data-tab="raw-playground">Raw Data Playground</button>
+        </div>
 
-        <section class="grid">
+        <section id="tab-dashboard" class="tab-panel active">
+        <div class="grid">
       <!-- PANEL 1: Data inputs & diagnostics -->
       <div class="panel card" style="grid-column:1 / -1;">
         <h3>Data Inputs & Diagnostics <span class="help" data-help="Upload monthly keyword spreadsheets to drive the charts and check for missing data." data-testid="help-inputs">?</span></h3>
@@ -242,6 +264,33 @@
         <div id="heatmap" class="chart" data-testid="heatmap"><div class="placeholder">Awaiting data…</div></div>
         <div class="status">This chart shows the top K zero-result keywords by total count across months, where darker means more empty (zero-result) searches.</div>
       </div>
+        </div>
+        </section>
+
+        <section id="tab-raw-playground" class="tab-panel panel card">
+          <h3>Raw Data Playground — Visual Data Modeler</h3>
+          <div class="playground-shell">
+            <div class="playground-toolbar">
+              <button id="btn-add-node" class="btn">+ Add Perspective Widget</button>
+              <button id="btn-link-mode" class="btn ghost">Link mode: Off</button>
+              <button id="btn-clear-links" class="btn ghost">Clear Links</button>
+              <div class="chip">
+                <label>Parent field</label>
+                <input id="parent-field" type="text" value="keyword" />
+              </div>
+              <div class="chip">
+                <label>Child field</label>
+                <input id="child-field" type="text" value="keyword" />
+              </div>
+            </div>
+            <div id="mapping-list" class="mapping-list">No links yet.</div>
+            <div id="canvas-wrap" class="canvas-wrap">
+              <div id="link-layer" class="link-layer">
+                <svg id="link-svg" width="100%" height="100%"></svg>
+              </div>
+              <div id="canvas-inner" class="canvas-inner"></div>
+            </div>
+          </div>
         </section>
       </div>
       <aside class="author-column">
@@ -358,7 +407,180 @@
         }
       }
 
-    const state = {
+      function initTabs(){
+        const tabButtons = document.querySelectorAll('.tab-btn');
+        const tabPanels = document.querySelectorAll('.tab-panel');
+        tabButtons.forEach(btn=>{
+          btn.addEventListener('click', ()=>{
+            const target = btn.dataset.tab;
+            tabButtons.forEach(b=> b.classList.toggle('active', b === btn));
+            tabPanels.forEach(panel=> panel.classList.toggle('active', panel.id === `tab-${target}`));
+            window.dispatchEvent(new Event('resize'));
+          });
+        });
+      }
+
+      function getCombinedRows(){
+        return state.sourceRaw.map((r, idx)=>({
+          id: idx + 1,
+          source: 'popular',
+          month: toMonthKey(r.month),
+          keyword: String(r.keyword || ''),
+          value: Number.isFinite(asNumber(r.percentage)) ? asNumber(r.percentage) : 0
+        })).concat(state.zeroRaw.map((r, idx)=>({
+          id: state.sourceRaw.length + idx + 1,
+          source: 'zero',
+          month: toMonthKey(r.month),
+          keyword: String(r.keyword || ''),
+          value: Number.isFinite(asNumber(r.count)) ? asNumber(r.count) : 0
+        })));
+      }
+
+      async function ensurePerspectiveLoaded(){
+        if(state.playground.pspReady) return true;
+        const urls = [
+          'https://cdn.jsdelivr.net/npm/@finos/perspective@2.11.0/dist/cdn/perspective.js',
+          'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer@2.11.0/dist/cdn/perspective-viewer.js',
+          'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-datagrid@2.11.0/dist/cdn/perspective-viewer-datagrid.js',
+          'https://cdn.jsdelivr.net/npm/@finos/perspective-viewer-d3fc@2.11.0/dist/cdn/perspective-viewer-d3fc.js'
+        ];
+        try{
+          for(const url of urls){
+            // eslint-disable-next-line no-await-in-loop
+            await new Promise((resolve, reject)=>{
+              const s = document.createElement('script');
+              s.src = url;
+              s.onload = resolve;
+              s.onerror = reject;
+              document.head.appendChild(s);
+            });
+          }
+          state.playground.pspReady = true;
+          return true;
+        }catch(e){
+          setStatus('Perspective.js failed to load for raw playground');
+          return false;
+        }
+      }
+
+      function updateMappingsLabel(){
+        const el = document.getElementById('mapping-list');
+        if(!el) return;
+        if(!state.playground.links.length){
+          el.textContent = 'No links yet.';
+          return;
+        }
+        el.innerHTML = state.playground.links.map((l, i)=>`${i+1}. parent #${l.parentId} → child #${l.childId} (${l.parentField} → ${l.childField})`).join('<br>');
+      }
+
+      function findNode(nodeId){
+        return state.playground.nodes.find(n=>n.id === nodeId);
+      }
+
+      function renderLinks(){
+        const svg = document.getElementById('link-svg');
+        const wrap = document.getElementById('canvas-wrap');
+        if(!svg || !wrap) return;
+        const rect = wrap.getBoundingClientRect();
+        svg.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`);
+        svg.innerHTML = state.playground.links.map(link=>{
+          const p = findNode(link.parentId);
+          const c = findNode(link.childId);
+          if(!p || !c) return '';
+          const x1 = p.x + 210 - wrap.scrollLeft;
+          const y1 = p.y + 145 - wrap.scrollTop;
+          const x2 = c.x + 210 - wrap.scrollLeft;
+          const y2 = c.y + 145 - wrap.scrollTop;
+          const cx = (x1 + x2) / 2;
+          return `<path d="M ${x1} ${y1} C ${cx} ${y1}, ${cx} ${y2}, ${x2} ${y2}" stroke="#4C9AFF" stroke-width="2" fill="none"></path>`;
+        }).join('');
+      }
+
+      async function createPlaygroundNode(){
+        const ok = await ensurePerspectiveLoaded();
+        if(!ok) return;
+        const canvas = document.getElementById('canvas-inner');
+        if(!canvas) return;
+        const id = state.playground.nextId++;
+        const node = { id, x: 120 + (id-1) * 40, y: 120 + (id-1) * 30 };
+        state.playground.nodes.push(node);
+        const el = document.createElement('div');
+        el.className = 'node-card';
+        el.style.left = `${node.x}px`;
+        el.style.top = `${node.y}px`;
+        el.dataset.nodeId = String(id);
+        el.innerHTML = `<div class="node-head"><div class="node-meta">Widget #${id}</div><button class="btn ghost" data-node-link="${id}" style="padding:4px 8px">Select</button></div><div class="node-body"><perspective-viewer></perspective-viewer></div>`;
+        canvas.appendChild(el);
+        const viewer = el.querySelector('perspective-viewer');
+        const rows = getCombinedRows();
+        const table = await window.perspective.worker().table(rows.length ? rows : [{id:1, source:'empty', month:'-', keyword:'-', value:0}]);
+        await viewer.load(table);
+        await viewer.restore({settings:true, plugin:'Datagrid'});
+
+        const head = el.querySelector('.node-head');
+        head.addEventListener('mousedown', (evt)=>{
+          if(evt.target.closest('button')) return;
+          evt.preventDefault();
+          const startX = evt.clientX;
+          const startY = evt.clientY;
+          const baseX = node.x;
+          const baseY = node.y;
+          const onMove = (e)=>{
+            node.x = Math.max(0, baseX + e.clientX - startX);
+            node.y = Math.max(0, baseY + e.clientY - startY);
+            el.style.left = `${node.x}px`;
+            el.style.top = `${node.y}px`;
+            renderLinks();
+          };
+          const onUp = ()=>{
+            document.removeEventListener('mousemove', onMove);
+            document.removeEventListener('mouseup', onUp);
+          };
+          document.addEventListener('mousemove', onMove);
+          document.addEventListener('mouseup', onUp);
+        });
+        el.querySelector('[data-node-link]').addEventListener('click', ()=>{
+          if(!state.playground.linkMode) return;
+          if(!state.playground.selectedParentId){
+            state.playground.selectedParentId = id;
+            setStatus(`Link mode: parent selected (#${id}), click child next`);
+          }else if(state.playground.selectedParentId !== id){
+            state.playground.links.push({
+              parentId: state.playground.selectedParentId,
+              childId: id,
+              parentField: document.getElementById('parent-field').value.trim() || 'keyword',
+              childField: document.getElementById('child-field').value.trim() || 'keyword'
+            });
+            state.playground.selectedParentId = null;
+            updateMappingsLabel();
+            renderLinks();
+          }
+        });
+        renderLinks();
+      }
+
+      function initPlayground(){
+        const addBtn = document.getElementById('btn-add-node');
+        const linkBtn = document.getElementById('btn-link-mode');
+        const clearBtn = document.getElementById('btn-clear-links');
+        const wrap = document.getElementById('canvas-wrap');
+        if(!addBtn || !linkBtn || !clearBtn || !wrap) return;
+        addBtn.addEventListener('click', createPlaygroundNode);
+        linkBtn.addEventListener('click', ()=>{
+          state.playground.linkMode = !state.playground.linkMode;
+          state.playground.selectedParentId = null;
+          linkBtn.textContent = `Link mode: ${state.playground.linkMode ? 'On' : 'Off'}`;
+        });
+        clearBtn.addEventListener('click', ()=>{
+          state.playground.links = [];
+          state.playground.selectedParentId = null;
+          updateMappingsLabel();
+          renderLinks();
+        });
+        wrap.addEventListener('scroll', renderLinks);
+      }
+
+      const state = {
         charts: { race: null, zeros: null, trails: null, heatmap: null },
         sourceRaw: [], zeroRaw: [], zeroTotals: [],
         months: [],
@@ -368,7 +590,8 @@
         keywordFilter: [],
         heatTimeStartIdx: 0, heatTimeEndIdx: 0, heatTimeRangeInitialized: false, trailsLegendPage: 0, trailsLegendCols: 3, trailsLegendRows: 2, trailsLegendTotalPages: 1,
         // default data autoload flags
-        manualSource: false, manualZero: false, defaultsTried: false
+        manualSource: false, manualZero: false, defaultsTried: false,
+        playground: { nextId: 1, linkMode: false, selectedParentId: null, nodes: [], links: [], pspReady: false }
       };
 
       const ICON_DOWNLOAD = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>`;
@@ -1276,6 +1499,8 @@
 
       initHelp();
       initAuthorToggle();
+      initTabs();
+      initPlayground();
 
       // Try to autoload defaults on boot (works on GitHub Pages when files are in repo)
       autoLoadDefaults();

--- a/index.html
+++ b/index.html
@@ -445,7 +445,8 @@
           'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/variables.css',
           'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/icons.css',
           'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/pro.css',
-          'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/themes.css'
+          'https://unpkg.com/@finos/perspective-viewer@3.8.0/dist/css/themes.css',
+          'https://unpkg.com/@finos/perspective-viewer-d3fc@3.8.0/dist/css/perspective-viewer-d3fc.css'
         ];
         state.playground.pspStylesPromise = Promise.all(cssUrls.map((href)=> new Promise((resolve)=>{
           const existing = document.querySelector(`link[data-psp-style="${href}"]`);


### PR DESCRIPTION
### Motivation
- Provide an interactive second workspace where users can place editable Perspective.js widgets and visually model relationships between datasets. 
- Enable exploratory workflows (drag-drop widgets, link parent→child by fields) without changing backend or project structure.

### Description
- Add a tabbed UI with `Dashboard` and `Raw Data Playground` tabs and new CSS rules for tabs, the playground toolbar, an oversized scrollable canvas, widget cards, and an SVG link overlay. 
- Introduce a `Raw Data Playground` panel in `index.html` with controls (`#btn-add-node`, `#btn-link-mode`, `#btn-clear-links`, `#parent-field`, `#child-field`) and canvas elements (`#canvas-wrap`, `#canvas-inner`, `#link-svg`).
- Implement client-side playground logic: `ensurePerspectiveLoaded()` lazy-loads Perspective.js and viewer plugins from CDNs, `createPlaygroundNode()` instantiates draggable widget cards with embedded `<perspective-viewer>` tables backed by `getCombinedRows()` (combined `sourceRaw` + `zeroRaw`), and link creation stores mapping metadata (parent/child IDs and fields).
- Add SVG curved-link rendering (`renderLinks()`), state extension `state.playground`, and initialization functions `initTabs()` and `initPlayground()` wired into the existing bootstrap flow.

### Testing
- Ran an automated inline script syntax validation using Node with `new Function` for all inline `<script>` blocks in `index.html`, which succeeded for 3 script blocks. 
- No browser/visual automated tests were executed in this environment (UI interactions and Perspective runtime were not exercised here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba9a309d48832e8ac6a5ae64c7553b)